### PR TITLE
Update to 1.1.0.0

### DIFF
--- a/Touch-N-Stars/Properties/AssemblyInfo.cs
+++ b/Touch-N-Stars/Properties/AssemblyInfo.cs
@@ -6,8 +6,8 @@ using System.Runtime.InteropServices;
 
 // [MANDATORY] The assembly versioning
 //Should be incremented for each new release build of a plugin
-[assembly: AssemblyVersion("1.0.9.0")]
-[assembly: AssemblyFileVersion("1.0.9.0")]
+[assembly: AssemblyVersion("1.1.0.0")]
+[assembly: AssemblyFileVersion("1.1.0.0")]
 
 // [MANDATORY] The name of your plugin
 [assembly: AssemblyTitle("Touch 'N' Stars")]

--- a/Touch-N-Stars/Server/TouchNStarsServer.cs
+++ b/Touch-N-Stars/Server/TouchNStarsServer.cs
@@ -18,7 +18,7 @@ namespace TouchNStars.Server {
         private CancellationTokenSource apiToken;
         public WebServer WebServer;
 
-        private readonly List<string> appEndPoints = ["equipment", "camera", "autofocus", "mount", "guider", "sequence", "settings", "seq-mon", "flat", "dome", "logs", "switch", "flats", "stellarium"];
+        private readonly List<string> appEndPoints = ["equipment", "camera", "autofocus", "mount", "guider", "sequence", "settings", "seq-mon", "flat", "dome", "logs", "switch", "flats", "stellarium", "plugin1", "plugin2", "plugin3", "plugin4", "plugin5", "plugin6", "plugin7", "plugin8", "plugin9"];
 
         private int port;
         public TouchNStarsServer(int port) => this.port = port;


### PR DESCRIPTION
## [1.1.0.0] - 2025-07-25
### Added
- PHD2 setting support. You can now set many PHD2 parameters, such as exposure time, aggression, ...
- Display of the current `targetName` if a sequence item with status `RUNNING` exists.
- Autoscan for iOS and Andriod. The connection settings can now be determined automatically as long as the default port 5000 is used in the plugin
- In landscape, the navbar is now displayed on the left so there is more space
- Warning if the Locatoin Sync in NINA does not match TNS and the possibility to change this
- A window to set the camera's exposure time more quickly
- GuiderStatus component showing current guider state with visual indicators and multilingual support
- Added sequence load to load sequences into the advanced sequence. Load a sequence from the default sequence folder 

### Changed
- the coordinates for framing are no longer set at startup. This means that it is no longer necessary to switch to the framing tab in NINA
- design adjustments 
- Guidegraph show px and rms error
- Raise the API minimum version to API 2.2.5.0 !
- Toast notification system: Non-critical toasts now appear as non-blocking notifications in top-right corner, while confirmations and critical messages remain as blocking overlays
- Guider control buttons are now always clickable with visual feedback for inactive states

### Fixed
- fixed layout error in footer for iOS